### PR TITLE
transform abstracts to vectors with DistilBert

### DIFF
--- a/orion/packages/nlp/tests/test_text2vec.py
+++ b/orion/packages/nlp/tests/test_text2vec.py
@@ -17,8 +17,8 @@ def test_text_encoder():
     tv = Text2Vector()
     result = tv.encode_text(text)
 
-    expected_shape = torch.Size([1, 9])
-    expected_values = torch.tensor([[2, 10975, 126, 9, 4310, 111, 748, 187, 3]])
+    expected_shape = torch.Size([1, 8])
+    expected_values = torch.tensor([[101, 7592, 2088, 1012, 29379, 3347, 999, 102]])
 
     assert result.shape == expected_shape
     assert torch.all(result.eq(expected_values))

--- a/orion/packages/nlp/text2vec.py
+++ b/orion/packages/nlp/text2vec.py
@@ -1,6 +1,6 @@
 import torch
 import numpy as np
-from transformers import AlbertModel, AlbertTokenizer
+from transformers import DistilBertModel, DistilBertTokenizer
 import tensorflow as tf
 import sentencepiece as spm
 import tensorflow_hub as hub
@@ -10,13 +10,13 @@ USE = "https://tfhub.dev/google/universal-sentence-encoder/4"
 
 
 class Text2Vector:
-    """Transform text to vector using Albert."""
+    """Transform text to vector using DistilBert from HuggingFace."""
 
     def __init__(
         self,
-        tokenizer_model=AlbertTokenizer,
-        transformer=AlbertModel,
-        pretrained_weights="albert-base-v2",
+        tokenizer_model=DistilBertTokenizer,
+        transformer=DistilBertModel,
+        pretrained_weights="distilbert-base-uncased",
     ):
         self.tokenizer_model = tokenizer_model
         self.transformer = transformer
@@ -29,7 +29,7 @@ class Text2Vector:
 
         Args:
             text (str): Text input.
-            tokenizer_model (transformers.tokenization_albert.AlbertTokenizer): Pretrained tokenizer.
+            tokenizer_model (transformers.tokenization_distilbert.DistilBertTokenizer): Pretrained tokenizer.
                The tokenizer must match the transformer architecture that will be used.
             pretrained_weights (str): Pretrained weights shortcut.
 
@@ -48,7 +48,7 @@ class Text2Vector:
 
         Args:
             input_ids (torch.Tensor) Indices of input sequence tokens in the vocabulary of the transformer.
-            model_class (transformers.modeling_albert.AlbertModel): Pretrained transformer.
+            model_class (transformers.modeling_distilbert.DistilBertModel): Pretrained transformer.
             pretrained_weights (str): Pretrained weights shortcut.
 
         Returns:


### PR DESCRIPTION
Use DistilBert instead of Albert to produce abstract vectors.

Closes #97 