### PR TITLE
Topic filtering patch

### DIFF
--- a/orion/core/dags/orion.py
+++ b/orion/core/dags/orion.py
@@ -42,6 +42,7 @@ from orion.core.operators.postgresql2es_task import Postgreqsl2ElasticSearchOper
 from orion.packages.mag.create_tables import create_db_and_tables
 from dotenv import load_dotenv, find_dotenv
 import os
+import logging
 
 load_dotenv(find_dotenv())
 

--- a/orion/core/dags/orion.py
+++ b/orion/core/dags/orion.py
@@ -42,7 +42,6 @@ from orion.core.operators.postgresql2es_task import Postgreqsl2ElasticSearchOper
 from orion.packages.mag.create_tables import create_db_and_tables
 from dotenv import load_dotenv, find_dotenv
 import os
-import logging
 
 load_dotenv(find_dotenv())
 
@@ -57,8 +56,6 @@ DAG_ID = "orion"
 db_name = orion.config["data"]["db_name"]
 DB_CONFIG = os.getenv(db_name)
 MAG_API_KEY = os.getenv("mag_api_key")
-
-# query_mag
 MAG_OUTPUT_BUCKET = orion.config["s3_buckets"]["mag"]
 mag_config = orion.config["data"]["mag"]
 query_values = mag_config["query_values"]

--- a/orion/core/operators/create_viz_tables_task.py
+++ b/orion/core/operators/create_viz_tables_task.py
@@ -160,7 +160,7 @@ class CreateVizTables(BaseOperator):
         ):
             # logging.info(f"fos id: {row['field_of_study_id']}")
             g = (
-                df[df.field_of_study_id.isin(row["all_children"])]
+                df[df.field_of_study_id == row["field_of_study_id"]]
                 .drop_duplicates("paper_id")
                 .groupby(["country", "year"])
             )
@@ -236,13 +236,13 @@ class CreateVizTables(BaseOperator):
                     count=len(
                         set(
                             paper_fos[
-                                paper_fos.field_of_study_id.isin(row["all_children"])
+                                paper_fos.field_of_study_id == row["field_of_study_id"]
                             ]["paper_id"]
                         )
                     ),
                     paper_ids=set(
                         paper_fos[
-                            paper_fos.field_of_study_id.isin(row["all_children"])
+                            paper_fos.field_of_study_id == row["field_of_study_id"]
                         ]["paper_id"]
                     ),
                 )
@@ -273,7 +273,7 @@ class CreateVizTables(BaseOperator):
 
         for paper_id, fos_lst in g.iteritems():
             for _, row in filtered_fos.iterrows():
-                if len(set(fos_lst).intersection(set(row["all_children"]))) > 0:
+                if row["field_of_study_id"] in set(fos_lst):
                     d[paper_id].append(row["name"])
 
         store_on_s3(d, "document-vectors", "paper_topics")


### PR DESCRIPTION
Instead of assigning level 1 topics to papers by looking at the lower levels of the MAG hierarchy, I now use the level 1 topics directly. This fixes the overshooting (an extreme example, there are 1,681 papers on Biochemistry but the previous method assigned that topic to ~57K papers). I also had to change how we measure gender diversity:
- [x]  Change how we measure gender diversity
- [x]  Add % of papers covered by the topics
- [x]  Change how we create the `CountryTopicOutput` table
- [x]  Change how we create the `PaperTopics` table
- [x]  Change how we create the `PaperTopicsGrouped` table

Closes #131 
Closes #121 