### PR TITLE
Fix extreme metrics values

### DIFF
--- a/model_config.yaml
+++ b/model_config.yaml
@@ -48,7 +48,7 @@ gender_diversity:
 
 metrics:
     year: '2013'
-    paper_count_low: 5
+    paper_count_low: 10
     paper_count_high: 40 
     fos_count: 10
 

--- a/orion/core/dags/orion.py
+++ b/orion/core/dags/orion.py
@@ -206,7 +206,7 @@ with DAG(
         task_id="rca_measurement",
         db_config=DB_CONFIG,
         year_thresh=year_thresh,
-        paper_thresh=paper_thresh_high,
+        paper_thresh=paper_thresh_low,
     )
 
     text2vector = Text2SentenceBertOperator(

--- a/orion/core/operators/calculate_metrics_task.py
+++ b/orion/core/operators/calculate_metrics_task.py
@@ -343,8 +343,12 @@ class GenderDiversityOperator(BaseOperator):
             )
 
             # Countries with more than N papers in a year
-            # paper_count = df.drop_duplicates(subset=["country", "paper_id", "year"]).groupby(["year", "country"])["paper_id"].count()
-            # paper_count = paper_count.where(paper_count > self.paper_thresh).dropna()
+            paper_count = (
+                df.drop_duplicates(subset=["country", "paper_id", "year"])
+                .groupby(["year", "country"])["paper_id"]
+                .count()
+            )
+            paper_count = paper_count.where(paper_count > self.paper_thresh).dropna()
 
             # Country level share of female co-authors
             country_level = (
@@ -353,7 +357,9 @@ class GenderDiversityOperator(BaseOperator):
                 .mean()
             )
             # Keep only countries with more than N papers
-            # country_level = country_level.where(country_level.index.isin(paper_count.index)).dropna()
+            country_level = country_level.where(
+                country_level.index.isin(paper_count.index)
+            ).dropna()
 
             logging.info(f"Country level frame: {country_level.shape}")
 


### PR DESCRIPTION
Found a bug in the calculation of RCA. Instead of filtering out countries by the number of papers, it used the number of citations. Patching the bug and increasing the threshold fixed the issue. I also applied the same rule when measuring gender diversity.

Closes #142 