### PR TITLE
Patch affiliation type task

### DIFF
--- a/orion/core/orms/mag_orm.py
+++ b/orion/core/orms/mag_orm.py
@@ -401,7 +401,7 @@ class AffiliationType(Base):
     id = Column(
         BIGINT, ForeignKey("mag_affiliation.id"), primary_key=True, autoincrement=False
     )
-    type = Column(Integer)
+    non_industry = Column(Integer)
 
 
 class WorldBankGDP(Base):


### PR DESCRIPTION
Fixes a bug in the `affiliation_type_task` that would make jobs fail when an affiliation id was already in the AffiliationType table. 

Closes #140 
Closes #139 